### PR TITLE
Update WebLogsDatabase.cs

### DIFF
--- a/WebLogsDatabase.cs
+++ b/WebLogsDatabase.cs
@@ -35,6 +35,7 @@ namespace Fenton.WebLogImporter
             using var connection = new SqlConnection(_db);
             using SqlCommand command = _commands.GetBulkInsertCommand(connection);
             connection.Open();
+            command.CommandTimeout = 3600; // 3600 seconds = 1 hour
             command.ExecuteNonQuery();
         }
 


### PR DESCRIPTION
When there are too many log files, it was giving timeout. I have added a new line "command.CommandTimeout = 3600; // 3600 seconds = 1 hour" to fix the timeout problem